### PR TITLE
Add focus.thedev.id

### DIFF
--- a/cname.list
+++ b/cname.list
@@ -11,7 +11,7 @@ codeize: codeize.github.io
 dendydharmawan: dendydharmawan.vercel.app
 eagleanurag: eagleanurag.github.io
 fivenine: fivenine01.github.io
-focus: hifocus.github.io
+focus: ffork.github.io
 frans: thedev.netlify.app
 goose: scalgoon.github.io
 kai: kaidevs.github.io

--- a/cname.list
+++ b/cname.list
@@ -11,6 +11,7 @@ codeize: codeize.github.io
 dendydharmawan: dendydharmawan.vercel.app
 eagleanurag: eagleanurag.github.io
 fivenine: fivenine01.github.io
+focus: hifocus.github.io
 frans: thedev.netlify.app
 goose: scalgoon.github.io
 kai: kaidevs.github.io


### PR DESCRIPTION
Hi, I would like to have the subdomain `focus`. Hope this is ok.

A GitHub Pages had been setup and aliased to focus.thedev.id . The repository is private.

Just want to mention it's currently impossible to add the custom domains to both vercel or netlify. They both said the domain is owned by someone else so I would assume it was someone who added the apex domain itself to both platforms (to use its DNS dashboard, instead of simply add-as-custom-domain). I hope this situation can be sorted out as GitHub Pages is not that ideal for me.

Many thanks for the support.