### PR TITLE
ad4ad.thedev.id

### DIFF
--- a/cname.list
+++ b/cname.list
@@ -8,6 +8,7 @@
  */
 
 aalfiann: aalfiann.github.io
+ad4ad: 998b1659-7b33-48bb-8436-c8ec5bc88f41.repl.co
 adryzz: adryzz.github.io
 aktindo: aktindo.github.io
 anil: anilseervi.github.io


### PR DESCRIPTION
Since this is hosted on repl.it, the `CNAME` provided is different from the actual url. The actual site is located at [ad.aakhilv.repl.co](https://ad.aakhilv.repl.co).