### PR TITLE
Update bal.thedev.id

### DIFF
--- a/subdomains.json
+++ b/subdomains.json
@@ -10,7 +10,7 @@
   "ash-hnry": "ash-hnry.github.io",
   "appls": "appls2appls.github.io",
   "ayush": "iddev5.github.io",
-  "bal": "balloon.bbs.yt",
+  "bal": "vps35.heliohost.us",
   "bd103": "bd103.github.io",
   "cozmo": "cozmodev.github.io",
   "crispy": "crispy-cream.github.io",


### PR DESCRIPTION
I got a VPS in USA, Powered by [HelioHost](https://www.heliohost.org/) [VPS](https://www.heliohost.org/vps/). https://bal.thedev.id/ will change to delivery from this VPS.
- CNAME target has web: https://vps35.heliohost.us/
- The repository will be maintained in the future: https://github.com/fu-sen/bal.thedev.id
- At the time of this request, www.heliohost.org has a temporary server down. Please allow time if confirmation is required:
 https://www.helionet.org/index/topic/44338-resizing-backup-storage/
